### PR TITLE
Fix the coding style

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,7 +7,6 @@
     convertWarningsToExceptions="true"
     processIsolation="false"
     stopOnFailure="false"
-    syntaxCheck="true"
     bootstrap="vendor/autoload.php"
     colors="true">
     <testsuites>

--- a/src/Base64Url.php
+++ b/src/Base64Url.php
@@ -19,16 +19,16 @@ namespace Base64Url;
 final class Base64Url
 {
     /**
-     * @param string $data        The data to encode
-     * @param bool   $use_padding If true, the "=" padding at end of the encoded value are kept, else it is removed
+     * @param string $data       The data to encode
+     * @param bool   $usePadding If true, the "=" padding at end of the encoded value are kept, else it is removed
      *
      * @return string The data encoded
      */
-    public static function encode(string $data, bool $use_padding = false): string
+    public static function encode(string $data, bool $usePadding = false): string
     {
         $encoded = \strtr(\base64_encode($data), '+/', '-_');
 
-        return true === $use_padding ? $encoded : \rtrim($encoded, '=');
+        return true === $usePadding ? $encoded : \rtrim($encoded, '=');
     }
 
     /**

--- a/tests/Base64UrlTest.php
+++ b/tests/Base64UrlTest.php
@@ -17,12 +17,12 @@ class Base64UrlTest extends TestCase
     /**
      * @dataProvider getTestVectors
      */
-    public function testEncodeAndDecode(string $message, string $expected_result, bool $use_padding = false): void
+    public function testEncodeAndDecode(string $message, string $expectedResult, bool $usePadding = false): void
     {
-        $encoded = Base64Url::encode($message, $use_padding);
-        $decoded = Base64Url::decode($expected_result);
+        $encoded = Base64Url::encode($message, $usePadding);
+        $decoded = Base64Url::decode($expectedResult);
 
-        $this->assertEquals($expected_result, $encoded);
+        $this->assertEquals($expectedResult, $encoded);
         $this->assertEquals($message, $decoded);
     }
 


### PR DESCRIPTION
# Changed log
- Remove the `syntaxcheck` attribute because the latest `phpunit` version doesn't allow this.
- Organize the coding style and use the camel-case for the all source code.