### PR TITLE
Throw InvalidArgumentException when decoding nonsense data

### DIFF
--- a/src/Base64Url.php
+++ b/src/Base64Url.php
@@ -34,10 +34,17 @@ final class Base64Url
     /**
      * @param string $data The data to decode
      *
+     * @throws \InvalidArgumentException
+     *
      * @return string The data decoded
      */
     public static function decode(string $data): string
     {
-        return \base64_decode(\strtr($data, '-_', '+/'), true);
+        $decoded = \base64_decode(\strtr($data, '-_', '+/'), true);
+        if ($decoded === false) {
+            throw new \InvalidArgumentException('Invalid data provided');
+        }
+
+        return $decoded;
     }
 }

--- a/tests/Base64UrlTest.php
+++ b/tests/Base64UrlTest.php
@@ -109,4 +109,24 @@ class Base64UrlTest extends TestCase
             ],
         ];
     }
+
+    /**
+     * @dataProvider getTestNonsenseVectors
+     *
+     * @test
+     */
+    public function nonsenseInput(string $input): void
+    {
+        static::expectException(\InvalidArgumentException::class);
+        Base64Url::decode($input);
+    }
+
+    public function getTestNonsenseVectors(): array
+    {
+        return [
+            [
+                'cxr0fdsezrewklerewxoz423ocfsa3bw432yjydsa9lhdsalw',
+            ],
+        ];
+    }
 }


### PR DESCRIPTION
This PR is to resolve issue #11.

I've gone with the approach of throwing an `\InvalidArgumentException` when the value provided cannot be decoded, which seems more appropriate than allowing the method to throw a `TypeError` on returning `false`.

Another approach could have been to drop the type hint and allow the method to return `false` again as a valid return value; this feels like a matter of preference, but the move to using strict type hints makes me feel that the exception is more appropriate.